### PR TITLE
Check basewaypoints are populated before processing traffic light

### DIFF
--- a/ros/src/tl_detector/launch/tl_detector_site.launch
+++ b/ros/src/tl_detector/launch/tl_detector_site.launch
@@ -1,8 +1,8 @@
 <?xml version="1.0"?>
 <launch>
     <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node">
-<param name="model" value="frozen_inference_graph_sim_v1.4.pb" />    
-	</node>
+        <param name="model" value="frozen_inference_graph_sim_v1.4.pb" />    
+    </node>
     <node pkg="tl_detector" type="light_publisher.py" name="light_publisher" output="screen" cwd="node"/>
     
 </launch>

--- a/ros/src/tl_detector/launch/tl_detector_site.launch
+++ b/ros/src/tl_detector/launch/tl_detector_site.launch
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <launch>
-    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node"/>
+    <node pkg="tl_detector" type="tl_detector.py" name="tl_detector" output="screen" cwd="node">
+<param name="model" value="frozen_inference_graph_sim_v1.4.pb" />    
+	</node>
     <node pkg="tl_detector" type="light_publisher.py" name="light_publisher" output="screen" cwd="node"/>
+    
 </launch>

--- a/ros/src/tl_detector/tl_detector.py
+++ b/ros/src/tl_detector/tl_detector.py
@@ -79,6 +79,9 @@ class TLDetector(object):
             msg (Image): image from car-mounted camera
 
         """
+        if not self.waypoint_tree:
+            #Base Waypoints are not received yet.
+            return
         self.has_image = True
         self.camera_image = msg
         light_wp, state = self.process_traffic_lights()
@@ -133,9 +136,9 @@ class TLDetector(object):
             return False
 
         cv_image = self.bridge.imgmsg_to_cv2(self.camera_image, "bgr8")
-        return light.state
+        #return light.state
         #Get classification
-        #return self.light_classifier.get_classification(cv_image)
+        return self.light_classifier.get_classification(cv_image)
 
     def process_traffic_lights(self):
         closest_light = None


### PR DESCRIPTION
[ERROR] [1576307824.975826]: bad callback: <bound method TLDetector.image_cb of <__main__.TLDetector object at 0x7f9d65cf2490>>
Traceback (most recent call last):
  File "/opt/ros/kinetic/lib/python2.7/dist-packages/rospy/topics.py", line 750, in _invoke_callback
    cb(msg)
  File "/home/student/udacity/CarND-Capstone/ros/src/tl_detector/tl_detector.py", line 84, in image_cb
    light_wp, state = self.process_traffic_lights()
  File "/home/student/udacity/CarND-Capstone/ros/src/tl_detector/tl_detector.py", line 148, in process_traffic_lights
    car_wp_idx = self.get_closest_waypoint(self.pose.pose.position.x, self.pose.pose.position.y)
  File "/home/student/udacity/CarND-Capstone/ros/src/tl_detector/tl_detector.py", line 115, in get_closest_waypoint
    closest_idx = self.waypoint_tree.query([x,y], 1)[1]
AttributeError: 'NoneType' object has no attribute 'query'